### PR TITLE
Update module/start_chroot-script

### DIFF
--- a/src/config
+++ b/src/config
@@ -1,3 +1,3 @@
 export DIST_NAME=CommunityOS
-export DIST_VERSION=0.6.113
+export DIST_VERSION=0.6.114
 export MODULES="base(raspicam,network,disable-services(communityos),password-for-sudo)"

--- a/src/modules/communityos/start_chroot_script
+++ b/src/modules/communityos/start_chroot_script
@@ -537,7 +537,6 @@ if [ "$COMMUNITYOS_INCLUDE_WS7" == "yes" ]; then
   popd
   pushd /home/pi/LCD-show
   echo "--- Copying calibration files"
-  sudo cp -rf ./usr/share/X11/xorg.conf.d/99-fbturbo.conf-HDMI  /usr/share/X11/xorg.conf.d/99-fbturbo.conf
   sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-7-1024x600  /usr/share/X11/xorg.conf.d/99-calibration.conf
   sudo cat /home/pi/helpers/waveshare7-config >> /boot/config.txt
   if [ "$COMMUNITYOS_LCD_ROTATE" == "yes" ]; then
@@ -557,7 +556,6 @@ if [ "$COMMUNITYOS_INCLUDE_WS7B" == "yes" ]; then
   popd
   pushd /home/pi/LCD-show
   echo "--- Copying calibration files"
-  sudo cp -rf ./usr/share/X11/xorg.conf.d/99-fbturbo.conf-HDMI /usr/share/X11/xorg.conf.d/99-fbturbo.conf 
   sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-7-1024x600  /usr/share/X11/xorg.conf.d/99-calibration.conf
   sudo cat /home/pi/helpers/waveshare7b-config >> /boot/config.txt
   if [ "$COMMUNITYOS_LCD_ROTATE" == "yes" ]; then
@@ -577,7 +575,6 @@ if [ "$COMMUNITYOS_INCLUDE_WS5" == "yes" ]; then
   popd
   pushd /home/pi/LCD-show
   echo "--- Copying calibration files"
-  sudo cp -rf ./usr/share/X11/xorg.conf.d/99-fbturbo.conf-HDMI /usr/share/X11/xorg.conf.d/99-fbturbo.conf 
   sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5  /usr/share/X11/xorg.conf.d/99-calibration.conf
   sudo cat /home/pi/helpers/waveshare5-config >> /boot/config.txt
   if [ "$COMMUNITYOS_LCD_ROTATE" == "yes" ]; then
@@ -631,7 +628,6 @@ if [ "$COMMUNITYOS_INCLUDE_WS4" == "yes" ]; then
   popd
   pushd /home/pi/LCD-show
   echo "--- Copying calibration files"
-  sudo cp -rf ./usr/share/X11/xorg.conf.d/99-fbturbo.conf-HDMI /usr/share/X11/xorg.conf.d/99-fbturbo.conf 
   sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-5-270  /usr/share/X11/xorg.conf.d/99-calibration.conf
   sudo cat /home/pi/helpers/waveshare4-config >> /boot/config.txt
   if [ "$COMMUNITYOS_LCD_ROTATE" == "yes" ]; then
@@ -651,7 +647,6 @@ if [ "$COMMUNITYOS_INCLUDE_WS35" == "yes" ]; then
   popd
   pushd /home/pi/LCD-show
   echo "--- Copying calibration files"
-  sudo cp -rf ./usr/share/X11/xorg.conf.d/99-fbturbo.conf-HDMI /usr/share/X11/xorg.conf.d/99-fbturbo.conf 
   sudo cp -rf ./etc/X11/xorg.conf.d/99-calibration.conf-35H  /usr/share/X11/xorg.conf.d/99-calibration.conf
   sudo cat /home/pi/helpers/waveshare35-config >> /boot/config.txt
   if [ "$COMMUNITYOS_LCD_ROTATE" == "yes" ]; then


### PR DESCRIPTION
Remove all references to 99-fbturbo.conf as that messes up OctoPrint-TFT displaying on the screen.